### PR TITLE
Fix GPCRdb request by uppercasing all PDB codes.

### DIFF
--- a/scripts/mmseqs2.py
+++ b/scripts/mmseqs2.py
@@ -269,6 +269,8 @@ class MMSeqs2Runner:
                 sl = line.rstrip().split()
                 pdb = sl[1]
                 pdbid = pdb.split("_")[0]
+                # GPCRdb only accepts pdb codes in uppercase (otherwise the returned request will be empty)
+                pdbid = pdbid.upper()
                 if templates:
                     if templates[0] in ["Active", "Inactive", "Intermediate", "G protein", "Arrestin"] and pdbid not in check_duplicates and pdbid not in templates:
                         activation_state = templates[0]


### PR DESCRIPTION
Fixes #5

Currently, all requests to the GPCRdb fail, because the PDB codes are supplied in lowercase. Looking at old runs, apparently pdb70.m8 used to be constructed with uppercase PDB codes in the second column, which are now lowercase. I'm not sure if something changed in the MMseqs2 sequence search. 
Due to the failed GPCRdb requests, no templates can be found. Instead of raising an error, download_templates just returns an empty string as the database path, which leads to an HHsearch error.